### PR TITLE
feat: add video module with local storage

### DIFF
--- a/vue/xzs-admin/src/api/video.js
+++ b/vue/xzs-admin/src/api/video.js
@@ -1,0 +1,5 @@
+import { get } from '@/utils/request'
+
+export default {
+  list: query => get('/api/admin/video/list', query)
+}

--- a/vue/xzs-admin/src/router.js
+++ b/vue/xzs-admin/src/router.js
@@ -163,6 +163,18 @@ const constantRoutes = [
     ]
   },
   {
+    path: '/video',
+    component: Layout,
+    children: [
+      {
+        path: 'list',
+        component: () => import('@/views/video/list'),
+        name: 'VideoList',
+        meta: { title: '视频管理', icon: 'education', noCache: true }
+      }
+    ]
+  },
+  {
     path: '/education',
     component: Layout,
     name: 'EducationPage',

--- a/vue/xzs-admin/src/views/video/list.vue
+++ b/vue/xzs-admin/src/views/video/list.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="app-container">
+    <div style="margin-bottom:20px;">
+      <el-input v-model="title" placeholder="视频标题" style="width:200px;margin-right:10px" />
+      <el-upload :action="uploadUrl" :data="{title: title}" :show-file-list="false" @success="handleSuccess">
+        <el-button type="primary">上传视频</el-button>
+      </el-upload>
+    </div>
+    <el-table :data="list" style="width:100%">
+      <el-table-column prop="id" label="ID" width="60" />
+      <el-table-column prop="title" label="标题" />
+      <el-table-column label="操作" width="120">
+        <template slot-scope="scope">
+          <el-button type="text" @click="play(scope.row)">播放</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+    <el-dialog :visible.sync="dialogVisible" width="60%" title="播放">
+      <video v-if="current" :src="playUrl(current.id)" controls style="width:100%" />
+    </el-dialog>
+  </div>
+</template>
+
+<script>
+import api from '@/api/video'
+export default {
+  name: 'VideoList',
+  data () {
+    return {
+      list: [],
+      title: '',
+      dialogVisible: false,
+      current: null,
+      uploadUrl: process.env.VUE_APP_URL + '/api/admin/video/upload'
+    }
+  },
+  created () {
+    this.load()
+  },
+  methods: {
+    load () {
+      api.list().then(r => { this.list = r.response || [] })
+    },
+    handleSuccess () {
+      this.$message.success('上传成功')
+      this.load()
+    },
+    play (row) {
+      this.current = row
+      this.dialogVisible = true
+    },
+    playUrl (id) {
+      return process.env.VUE_APP_URL + '/api/admin/video/stream/' + id
+    }
+  }
+}
+</script>

--- a/vue/xzs-student/src/api/video.js
+++ b/vue/xzs-student/src/api/video.js
@@ -1,0 +1,5 @@
+import { get } from '@/utils/request'
+
+export default {
+  list: () => get('/api/student/video/list')
+}

--- a/vue/xzs-student/src/router.js
+++ b/vue/xzs-student/src/router.js
@@ -44,6 +44,18 @@ const router = new Router({
         }
       ]
     },
+      {
+        path: '/video',
+        component: Layout,
+        children: [
+          {
+            path: 'index',
+            component: () => import('@/views/video/index'),
+            name: 'VideoIndex',
+            meta: { title: '视频中心' }
+          }
+        ]
+      },
     {
       path: '/question',
       component: Layout,

--- a/vue/xzs-student/src/views/video/index.vue
+++ b/vue/xzs-student/src/views/video/index.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="app-container">
+    <el-table :data="list" style="width:100%">
+      <el-table-column prop="title" label="标题" />
+      <el-table-column label="播放" width="120">
+        <template slot-scope="scope">
+          <el-button type="text" @click="play(scope.row)">播放</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+    <el-dialog :visible.sync="dialogVisible" width="90%" title="播放">
+      <video v-if="current" :src="playUrl(current.id)" controls style="width:100%" />
+    </el-dialog>
+  </div>
+</template>
+
+<script>
+import api from '@/api/video'
+export default {
+  name: 'VideoIndex',
+  data () {
+    return {
+      list: [],
+      dialogVisible: false,
+      current: null
+    }
+  },
+  created () {
+    this.load()
+  },
+  methods: {
+    load () {
+      api.list().then(r => { this.list = r.response || [] })
+    },
+    play (row) {
+      this.current = row
+      this.dialogVisible = true
+    },
+    playUrl (id) {
+      return process.env.VUE_APP_URL + '/api/student/video/stream/' + id
+    }
+  }
+}
+</script>

--- a/xzs/src/main/java/com/mindskip/xzs/configuration/property/SystemConfig.java
+++ b/xzs/src/main/java/com/mindskip/xzs/configuration/property/SystemConfig.java
@@ -18,6 +18,8 @@ public class SystemConfig {
     private List<String> securityIgnoreUrls;
     private WxConfig wx;
     private QnConfig qn;
+    private String videoPath;
+
 
     /**
      * Gets pwd key.
@@ -89,6 +91,14 @@ public class SystemConfig {
      */
     public void setQn(QnConfig qn) {
         this.qn = qn;
+    }
+
+    public String getVideoPath() {
+        return videoPath;
+    }
+
+    public void setVideoPath(String videoPath) {
+        this.videoPath = videoPath;
     }
 
 }

--- a/xzs/src/main/java/com/mindskip/xzs/controller/admin/VideoController.java
+++ b/xzs/src/main/java/com/mindskip/xzs/controller/admin/VideoController.java
@@ -1,0 +1,48 @@
+package com.mindskip.xzs.controller.admin;
+
+import com.mindskip.xzs.base.BaseApiController;
+import com.mindskip.xzs.base.RestResponse;
+import com.mindskip.xzs.domain.Video;
+import com.mindskip.xzs.service.VideoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.MediaTypeFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController("AdminVideoController")
+@RequestMapping("/api/admin/video")
+public class VideoController extends BaseApiController {
+
+    private final VideoService videoService;
+
+    @Autowired
+    public VideoController(VideoService videoService) {
+        this.videoService = videoService;
+    }
+
+    @PostMapping("/upload")
+    public RestResponse<Video> upload(@RequestParam("file") MultipartFile file,
+                                      @RequestParam("title") String title) {
+        Video video = videoService.uploadVideo(file, title);
+        return RestResponse.ok(video);
+    }
+
+    @GetMapping("/list")
+    public RestResponse<List<Video>> list() {
+        return RestResponse.ok(videoService.list());
+    }
+
+    @GetMapping("/stream/{id}")
+    public ResponseEntity<Resource> stream(@PathVariable Integer id) {
+        Video video = videoService.selectById(id);
+        FileSystemResource resource = new FileSystemResource(video.getFilePath());
+        MediaType mediaType = MediaTypeFactory.getMediaType(resource).orElse(MediaType.APPLICATION_OCTET_STREAM);
+        return ResponseEntity.ok().contentType(mediaType).body(resource);
+    }
+}

--- a/xzs/src/main/java/com/mindskip/xzs/controller/student/VideoController.java
+++ b/xzs/src/main/java/com/mindskip/xzs/controller/student/VideoController.java
@@ -1,0 +1,40 @@
+package com.mindskip.xzs.controller.student;
+
+import com.mindskip.xzs.base.BaseApiController;
+import com.mindskip.xzs.base.RestResponse;
+import com.mindskip.xzs.domain.Video;
+import com.mindskip.xzs.service.VideoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.MediaTypeFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController("StudentVideoController")
+@RequestMapping("/api/student/video")
+public class VideoController extends BaseApiController {
+
+    private final VideoService videoService;
+
+    @Autowired
+    public VideoController(VideoService videoService) {
+        this.videoService = videoService;
+    }
+
+    @GetMapping("/list")
+    public RestResponse<List<Video>> list() {
+        return RestResponse.ok(videoService.list());
+    }
+
+    @GetMapping("/stream/{id}")
+    public ResponseEntity<Resource> stream(@PathVariable Integer id) {
+        Video video = videoService.selectById(id);
+        FileSystemResource resource = new FileSystemResource(video.getFilePath());
+        MediaType mediaType = MediaTypeFactory.getMediaType(resource).orElse(MediaType.APPLICATION_OCTET_STREAM);
+        return ResponseEntity.ok().contentType(mediaType).body(resource);
+    }
+}

--- a/xzs/src/main/java/com/mindskip/xzs/domain/Video.java
+++ b/xzs/src/main/java/com/mindskip/xzs/domain/Video.java
@@ -1,0 +1,53 @@
+package com.mindskip.xzs.domain;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class Video implements Serializable {
+
+    private Integer id;
+    private String title;
+    private String filePath;
+    private Date createTime;
+    private Boolean deleted;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title == null ? null : title.trim();
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath == null ? null : filePath.trim();
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+    public Boolean getDeleted() {
+        return deleted;
+    }
+
+    public void setDeleted(Boolean deleted) {
+        this.deleted = deleted;
+    }
+}

--- a/xzs/src/main/java/com/mindskip/xzs/repository/VideoMapper.java
+++ b/xzs/src/main/java/com/mindskip/xzs/repository/VideoMapper.java
@@ -1,0 +1,11 @@
+package com.mindskip.xzs.repository;
+
+import com.mindskip.xzs.domain.Video;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface VideoMapper extends BaseMapper<Video> {
+    List<Video> selectAll();
+}

--- a/xzs/src/main/java/com/mindskip/xzs/service/VideoService.java
+++ b/xzs/src/main/java/com/mindskip/xzs/service/VideoService.java
@@ -1,0 +1,11 @@
+package com.mindskip.xzs.service;
+
+import com.mindskip.xzs.domain.Video;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface VideoService extends BaseService<Video> {
+    Video uploadVideo(MultipartFile file, String title);
+    List<Video> list();
+}

--- a/xzs/src/main/java/com/mindskip/xzs/service/impl/VideoServiceImpl.java
+++ b/xzs/src/main/java/com/mindskip/xzs/service/impl/VideoServiceImpl.java
@@ -1,0 +1,58 @@
+package com.mindskip.xzs.service.impl;
+
+import com.mindskip.xzs.configuration.property.SystemConfig;
+import com.mindskip.xzs.domain.Video;
+import com.mindskip.xzs.repository.VideoMapper;
+import com.mindskip.xzs.service.VideoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Date;
+import java.util.List;
+
+@Service
+public class VideoServiceImpl extends BaseServiceImpl<Video> implements VideoService {
+
+    private final VideoMapper videoMapper;
+    private final SystemConfig systemConfig;
+
+    @Autowired
+    public VideoServiceImpl(VideoMapper videoMapper, SystemConfig systemConfig) {
+        super(videoMapper);
+        this.videoMapper = videoMapper;
+        this.systemConfig = systemConfig;
+    }
+
+    @Override
+    public Video uploadVideo(MultipartFile file, String title) {
+        String folder = systemConfig.getVideoPath();
+        File dir = new File(folder);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+        String fileName = System.currentTimeMillis() + "_" + file.getOriginalFilename();
+        Path path = Paths.get(folder, fileName);
+        try {
+            file.transferTo(path.toFile());
+        } catch (IOException e) {
+            throw new RuntimeException("save video error", e);
+        }
+        Video video = new Video();
+        video.setTitle(title);
+        video.setFilePath(path.toString());
+        video.setCreateTime(new Date());
+        video.setDeleted(false);
+        videoMapper.insertSelective(video);
+        return video;
+    }
+
+    @Override
+    public List<Video> list() {
+        return videoMapper.selectAll();
+    }
+}

--- a/xzs/src/main/resources/application.yml
+++ b/xzs/src/main/resources/application.yml
@@ -27,6 +27,7 @@ system:
     - /api/admin/upload/configAndUpload
     - /api/admin/upload/auth
     - /api/student/user/register
+    - /api/student/video/stream/**
   pwdKey:
     publicKey: MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQClwwxhJKwStDnu7c0yCRkwTW2VKuLWwyVtFC6Zx9bYdF1qwqSP26CkDwaF6GHayIvv9b8BHlAaQH4SLIPzir062yzNukqspmthUw4gPJhbx1AQrWRoQJSv3/1Sk+tWyJRHXSiCZJZ3216LDhtx42LQ0HItDP8U9BLtsxA+5LEZzQIDAQAB
     privateKey: MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAKXDDGEkrBK0Oe7tzTIJGTBNbZUq4tbDJW0ULpnH1th0XWrCpI/boKQPBoXoYdrIi+/1vwEeUBpAfhIsg/OKvTrbLM26Sqyma2FTDiA8mFvHUBCtZGhAlK/f/VKT61bIlEddKIJklnfbXosOG3HjYtDQci0M/xT0Eu2zED7ksRnNAgMBAAECgYEAlCuz5yn2volnt9HNuEo1v92WdN5vAnZSAB0oQsJFpBrwXjw7CXTTNZNQy2YcAot9uzO6Vu+Xvr+jce9ky9BasM7ehz0gnwJWAO79IqUnmu3RRq7HllDwp72qysXIypJZCF4HX5jAzUGlNzlTSUb1H4LtavKc6a//YqPfQ0jTLsECQQDZuGKGAYq6rBCX0+T8qlQpCPc41wsl4Gi9lLD21ks9PMx44JdhsUrqLWItZiGynDzq1LJ3M1hr3gbSsPQcI9HJAkEAwugDFCiRLOqOBRRGlYbzgGdmXbR4SrMNIpcFTFhU+MsEqaMueVPiNtRSIK6W8pS28ZN0aiZDTBAT84fOIENp5QJBAJaVgQ9OYbVa7N8WH3riE/ONz+/wTDWWUNtOzFbtQHzKYGH6dLmM9lOhsBXWXdg7V6bUFdt8F9wDZJS07yHHZIECQG4rHrJiS80Lt8L/NvaGFVVbHO2SePwgQShwHLqOo1kNyFDqv/YsiA1d7h4zEXeEv/PE2WS2xAtWezCIbualtFECQQDPUkYhs3vZoZgsltdeFnv/WoXaXNRIzunMTmksIlh8JP7C1xQHrwdCpUkffgSVphxGJGHkxooMpki7oTC1Mdjx
@@ -43,6 +44,7 @@ system:
     bucket: mindskip
     access-key: KabOBTPGVll2sSV8d1OIlW8G4_n_cReE7RSsLafA
     secret-key: mSltk9_9KtCdFetCmxvvCAgsBg8JZHiXMuQeqSJA
+  video-path: video
 
 
 #mybatis page helper

--- a/xzs/src/main/resources/mapper/VideoMapper.xml
+++ b/xzs/src/main/resources/mapper/VideoMapper.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.mindskip.xzs.repository.VideoMapper">
+  <resultMap id="BaseResultMap" type="com.mindskip.xzs.domain.Video">
+    <id column="id" jdbcType="INTEGER" property="id" />
+    <result column="title" jdbcType="VARCHAR" property="title" />
+    <result column="file_path" jdbcType="VARCHAR" property="filePath" />
+    <result column="create_time" jdbcType="TIMESTAMP" property="createTime" />
+    <result column="deleted" jdbcType="BIT" property="deleted" />
+  </resultMap>
+
+  <sql id="Base_Column_List">
+    id, title, file_path, create_time, deleted
+  </sql>
+
+  <select id="selectByPrimaryKey" parameterType="java.lang.Integer" resultMap="BaseResultMap">
+    select
+    <include refid="Base_Column_List" />
+    from t_video
+    where id = #{id,jdbcType=INTEGER}
+  </select>
+
+  <delete id="deleteByPrimaryKey" parameterType="java.lang.Integer">
+    delete from t_video where id = #{id,jdbcType=INTEGER}
+  </delete>
+
+  <insert id="insert" parameterType="com.mindskip.xzs.domain.Video" useGeneratedKeys="true" keyProperty="id">
+    insert into t_video (title, file_path, create_time, deleted)
+    values (#{title,jdbcType=VARCHAR}, #{filePath,jdbcType=VARCHAR}, #{createTime,jdbcType=TIMESTAMP}, #{deleted,jdbcType=BIT})
+  </insert>
+
+  <insert id="insertSelective" parameterType="com.mindskip.xzs.domain.Video" useGeneratedKeys="true" keyProperty="id">
+    insert into t_video
+    <trim prefix="(" suffix=")" suffixOverrides=",">
+      <if test="title != null">title,</if>
+      <if test="filePath != null">file_path,</if>
+      <if test="createTime != null">create_time,</if>
+      <if test="deleted != null">deleted,</if>
+    </trim>
+    <trim prefix="values (" suffix=")" suffixOverrides=",">
+      <if test="title != null">#{title,jdbcType=VARCHAR},</if>
+      <if test="filePath != null">#{filePath,jdbcType=VARCHAR},</if>
+      <if test="createTime != null">#{createTime,jdbcType=TIMESTAMP},</if>
+      <if test="deleted != null">#{deleted,jdbcType=BIT},</if>
+    </trim>
+  </insert>
+
+  <update id="updateByPrimaryKeySelective" parameterType="com.mindskip.xzs.domain.Video">
+    update t_video
+    <set>
+      <if test="title != null">title = #{title,jdbcType=VARCHAR},</if>
+      <if test="filePath != null">file_path = #{filePath,jdbcType=VARCHAR},</if>
+      <if test="createTime != null">create_time = #{createTime,jdbcType=TIMESTAMP},</if>
+      <if test="deleted != null">deleted = #{deleted,jdbcType=BIT},</if>
+    </set>
+    where id = #{id,jdbcType=INTEGER}
+  </update>
+
+  <update id="updateByPrimaryKey" parameterType="com.mindskip.xzs.domain.Video">
+    update t_video
+    set title = #{title,jdbcType=VARCHAR},
+        file_path = #{filePath,jdbcType=VARCHAR},
+        create_time = #{createTime,jdbcType=TIMESTAMP},
+        deleted = #{deleted,jdbcType=BIT}
+    where id = #{id,jdbcType=INTEGER}
+  </update>
+
+  <select id="selectAll" resultMap="BaseResultMap">
+    select <include refid="Base_Column_List" /> from t_video where deleted = 0 order by id desc
+  </select>
+</mapper>

--- a/xzs/src/main/resources/sql/video.sql
+++ b/xzs/src/main/resources/sql/video.sql
@@ -1,0 +1,7 @@
+CREATE TABLE t_video (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  file_path VARCHAR(512) NOT NULL,
+  create_time DATETIME NOT NULL,
+  deleted BIT DEFAULT b'0'
+);


### PR DESCRIPTION
## Summary
- add `t_video` table and MyBatis mappings
- allow admins to upload and stream locally stored videos
- expose student endpoints and Vue pages to list and play videos

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `npm test` (admin) *(fails: Missing script "test")*
- `npm test` (student) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad6fe8339c83319eeef6b5207ef0c7