### PR TITLE
Fix video route indentation and clean unused import

### DIFF
--- a/vue/xzs-student/src/api/question.js
+++ b/vue/xzs-student/src/api/question.js
@@ -1,4 +1,2 @@
-import { post } from '@/utils/request'
-
 export default {
 }

--- a/vue/xzs-student/src/router.js
+++ b/vue/xzs-student/src/router.js
@@ -44,18 +44,18 @@ const router = new Router({
         }
       ]
     },
-      {
-        path: '/video',
-        component: Layout,
-        children: [
-          {
-            path: 'index',
-            component: () => import('@/views/video/index'),
-            name: 'VideoIndex',
-            meta: { title: '视频中心' }
-          }
-        ]
-      },
+    {
+      path: '/video',
+      component: Layout,
+      children: [
+        {
+          path: 'index',
+          component: () => import('@/views/video/index'),
+          name: 'VideoIndex',
+          meta: { title: '视频中心' }
+        }
+      ]
+    },
     {
       path: '/question',
       component: Layout,


### PR DESCRIPTION
## Summary
- align `/video` route indentation with adjacent routes
- remove unused import in question API module

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad743ab57083319ff18fbf357242ff